### PR TITLE
feat: add recursive INNER JOIN support

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -134,10 +134,12 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
         switch (data.command) {
           case 'DELETE':
           case 'UPDATE':
-            result = {affectedRows: data.rowCount, count: data.rowCount};
+            result = {
+              affectedRows: data.rowCount,
+              count: data.rowCount,
+            };
 
-            if (data.rows)
-              result.rows = data.rows;
+            if (data.rows) result.rows = data.rows;
 
             break;
           default:
@@ -214,6 +216,53 @@ PostgreSQL.prototype.getDefaultIdSortPolicy = function(model) {
 };
 
 /**
+ * Build a list of escaped column names for the given model and fields filter
+ * @param {string} model Model name
+ * @param {object} filter The filter object
+ * @param {boolean} withTable If true prepend the table name (default false)
+ * @returns {string} Comma separated string of escaped column names
+ */
+PostgreSQL.prototype.buildColumnNames = function(model, filter, withTable = false) {
+  const fieldsFilter = filter && filter.fields;
+  const cols = this.getModelDefinition(model).properties;
+  if (!cols) {
+    return '*';
+  }
+  const self = this;
+  let keys = Object.keys(cols);
+  if (Array.isArray(fieldsFilter) && fieldsFilter.length > 0) {
+    // Not empty array, including all the fields that are valid properties
+    keys = fieldsFilter.filter(function(f) {
+      return cols[f];
+    });
+  } else if ('object' === typeof fieldsFilter &&
+    Object.keys(fieldsFilter).length > 0) {
+    // { field1: boolean, field2: boolean ... }
+    const included = [];
+    const excluded = [];
+    keys.forEach(function(k) {
+      if (fieldsFilter[k]) {
+        included.push(k);
+      } else if ((k in fieldsFilter) && !fieldsFilter[k]) {
+        excluded.push(k);
+      }
+    });
+    if (included.length > 0) {
+      keys = included;
+    } else if (excluded.length > 0) {
+      excluded.forEach(function(e) {
+        const index = keys.indexOf(e);
+        keys.splice(index, 1);
+      });
+    }
+  }
+  const names = keys.map(function(c) {
+    return self.columnEscaped(model, c, withTable);
+  });
+  return names.join(',');
+};
+
+/**
  * Build a SQL SELECT statement
  * @param {String} model Model name
  * @param {Object} filter Filter object
@@ -246,30 +295,98 @@ PostgreSQL.prototype.buildSelect = function(model, filter) {
     }
   }
 
-  let selectStmt = new ParameterizedSQL('SELECT ' +
-    this.buildColumnNames(model, filter) +
-    ' FROM ' + this.tableEscaped(model));
+  let selectStmt = new ParameterizedSQL(
+    'SELECT ' +
+    this.buildColumnNames(model, filter, true) +
+    ' FROM ' +
+    this.tableEscaped(model),
+  );
 
   if (filter) {
+    if (filter.where || filter.order) {
+      const {
+        joinStmt,
+        innerWhere,
+        innerOrder,
+      } = this.buildJoin(
+        model,
+        filter,
+      );
+      filter.innerWhere = innerWhere || {};
+      filter.innerOrder = innerOrder || {};
+      selectStmt.merge(joinStmt);
+    }
     if (filter.where) {
-      const whereStmt = this.buildWhere(model, filter.where);
+      const whereStmt = this.buildWhere(model, filter);
       selectStmt.merge(whereStmt);
     }
 
     if (filter.order) {
-      selectStmt.merge(this.buildOrderBy(model, filter.order));
+      selectStmt.merge(this.buildOrderBy(model, filter));
     }
 
     if (filter.limit || filter.skip || filter.offset) {
-      selectStmt = this.applyPagination(
-        model, selectStmt, filter,
-      );
+      selectStmt = this.applyPagination(model, selectStmt, filter);
     }
   }
   return this.parameterize(selectStmt);
 };
 
-PostgreSQL.prototype.buildInsertDefaultValues = function(model, data, options) {
+/**
+ * Build the ORDER BY clause
+ * @param {string} model Model name
+ * @param {string[]} order An array of sorting criteria
+ * @returns {string} The ORDER BY clause
+ */
+PostgreSQL.prototype.buildOrderBy = function(model, filter) {
+  const {
+    order,
+    innerOrder,
+  } = filter;
+  if (!order) {
+    return '';
+  }
+  const self = this;
+  let orderArray = order;
+  if (typeof order === 'string') {
+    orderArray = [order];
+  }
+  const clauses = [];
+  for (let i = 0, n = orderArray.length; i < n; i++) {
+    const t = orderArray[i].split(/[\s,]+/);
+    let value = false;
+    if (t.length === 2) {
+      value = true;
+    }
+    if (innerOrder && innerOrder[t[0]]) {
+      const column = self.columnEscaped(
+        innerOrder[t[0]].model,
+        innerOrder[t[0]].property.key,
+        true,
+        innerOrder[t[0]].prefix,
+      );
+      if (value) {
+        clauses.push(column + ' ' + t[1]);
+      } else {
+        clauses.push(column);
+      }
+    } else {
+      const column = self.columnEscaped(model, t[0], true);
+      if (value) {
+        clauses.push(column + ' ' + t[1]);
+      } else {
+        clauses.push(column);
+      }
+    }
+  }
+  return 'ORDER BY ' + clauses.join(',');
+};
+
+PostgreSQL.prototype.buildInsertDefaultValues = function(
+  model,
+  data,
+  options,
+) {
   return 'DEFAULT VALUES';
 };
 
@@ -336,10 +453,11 @@ PostgreSQL.prototype.fromColumnValue = function(prop, val) {
     if (typeof val === 'boolean') {
       return val;
     } else {
-      return (val === 'Y' || val === 'y' || val === 'T' ||
-      val === 't' || val === '1');
+      return (
+        val === 'Y' || val === 'y' || val === 'T' || val === 't' || val === '1'
+      );
     }
-  } else if (prop && type === 'GeoPoint' || type === 'Point') {
+  } else if ((prop && type === 'GeoPoint') || type === 'Point') {
     if (typeof val === 'string') {
       // The point format is (x,y)
       const point = val.split(/[\(\)\s,]+/).filter(Boolean);
@@ -390,10 +508,10 @@ function escapeIdentifier(str) {
 
 function escapeLiteral(str) {
   let hasBackslash = false;
-  let escaped = '\'';
+  let escaped = "'";
   for (let i = 0; i < str.length; i++) {
     const c = str[i];
-    if (c === '\'') {
+    if (c === "'") {
       escaped += c + c;
     } else if (c === '\\') {
       escaped += c + c;
@@ -402,7 +520,7 @@ function escapeLiteral(str) {
       escaped += c;
     }
   }
-  escaped += '\'';
+  escaped += "'";
   if (hasBackslash === true) {
     escaped = ' E' + escaped;
   }
@@ -423,20 +541,36 @@ function isNested(property) {
  * to allow querying nested json keys
  * @param {String} model The model name
  * @param {String} property The property name
+ * @param {boolean} if true prepend the table name (default= false)
+ * @param {String} add a prefix to column (for alias)
  * @returns {String} The escaped column name, or column with nested keys for deep json columns
  */
-PostgreSQL.prototype.columnEscaped = function(model, property) {
+PostgreSQL.prototype.columnEscaped = function(model, property, withTable = false, prefix = '') {
   if (isNested(property)) {
     // Convert column to PostgreSQL json style query: "model"->>'val'
     const self = this;
     return property
       .split('.')
-      .map(function(val, idx) { return (idx === 0 ? self.columnEscaped(model, val) : escapeLiteral(val)); })
+      .map(function(val, idx) {
+        return idx === 0 ? self.columnEscaped(model, val) : escapeLiteral(val);
+      })
       .reduce(function(prev, next, idx, arr) {
-        return idx == 0 ? next : idx < arr.length - 1 ? prev + '->' + next : prev + '->>' + next;
+        return idx == 0 ?
+          next :
+          idx < arr.length - 1 ?
+            prev + '->' + next :
+            prev + '->>' + next;
       });
   } else {
-    return this.escapeName(this.column(model, property));
+    if (withTable) {
+      return (
+        this.escapeName(prefix + this.table(model)) +
+        '.' +
+        this.escapeName(this.column(model, property))
+      );
+    } else {
+      return this.escapeName(this.column(model, property));
+    }
   }
 };
 
@@ -468,8 +602,7 @@ PostgreSQL.prototype.escapeValue = function(value) {
 
 PostgreSQL.prototype.tableEscaped = function(model) {
   const schema = this.schema(model) || 'public';
-  return this.escapeName(schema) + '.' +
-    this.escapeName(this.table(model));
+  return this.escapeName(schema) + '.' + this.escapeName(this.table(model));
 };
 
 function buildLimit(limit, offset) {
@@ -497,21 +630,32 @@ PostgreSQL.prototype.applyPagination = function(model, stmt, filter) {
   return stmt.merge(limitClause);
 };
 
-PostgreSQL.prototype.buildExpression = function(columnName, operator,
-  operatorValue, propertyDefinition) {
+PostgreSQL.prototype.buildExpression = function(
+  columnName,
+  operator,
+  operatorValue,
+  propertyDefinition,
+) {
   switch (operator) {
     case 'like':
-      return new ParameterizedSQL(columnName + "::TEXT LIKE ? ESCAPE E'\\\\'",
-        [operatorValue]);
+      return new ParameterizedSQL(columnName + "::TEXT LIKE ? ESCAPE E'\\\\'", [
+        operatorValue,
+      ]);
     case 'ilike':
-      return new ParameterizedSQL(columnName + "::TEXT ILIKE ? ESCAPE E'\\\\'",
-        [operatorValue]);
+      return new ParameterizedSQL(
+        columnName + "::TEXT ILIKE ? ESCAPE E'\\\\'",
+        [operatorValue],
+      );
     case 'nlike':
-      return new ParameterizedSQL(columnName + "::TEXT NOT LIKE ? ESCAPE E'\\\\'",
-        [operatorValue]);
+      return new ParameterizedSQL(
+        columnName + "::TEXT NOT LIKE ? ESCAPE E'\\\\'",
+        [operatorValue],
+      );
     case 'nilike':
-      return new ParameterizedSQL(columnName + "::TEXT NOT ILIKE ? ESCAPE E'\\\\'",
-        [operatorValue]);
+      return new ParameterizedSQL(
+        columnName + "::TEXT NOT ILIKE ? ESCAPE E'\\\\'",
+        [operatorValue],
+      );
     case 'regexp':
       if (operatorValue.global)
         g.warn('{{PostgreSQL}} regex syntax does not respect the {{`g`}} flag');
@@ -520,12 +664,18 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
         g.warn('{{PostgreSQL}} regex syntax does not respect the {{`m`}} flag');
 
       const regexOperator = operatorValue.ignoreCase ? ' ~* ?' : ' ~ ?';
-      return new ParameterizedSQL(columnName + regexOperator,
-        [operatorValue.source]);
+      return new ParameterizedSQL(columnName + regexOperator, [
+        operatorValue.source,
+      ]);
     default:
       // invoke the base implementation of `buildExpression`
-      return this.invokeSuper('buildExpression', columnName, operator,
-        operatorValue, propertyDefinition);
+      return this.invokeSuper(
+        'buildExpression',
+        columnName,
+        operator,
+        operatorValue,
+        propertyDefinition,
+      );
   }
 };
 
@@ -560,13 +710,225 @@ PostgreSQL.prototype.getInsertedId = function(model, info) {
 };
 
 /**
- * Build the SQL WHERE clause for the where object
+ * Build the INNER JOIN AS clauses for the filter.where object
+ * Prepare WHERE clause with the creation innerWhere object
+ * Prepare ORDER BY clause with the creation of innerOrder object
  * @param {string} model Model name
- * @param {object} where An object for the where conditions
+ * @param {object} filter An object for the filter
+ * @returns {object} An object with the INNER JOIN AS SQL statement innerWhere and innerOrder for next builders
+ */
+PostgreSQL.prototype.buildJoin = function(model, filter) {
+  const {
+    order,
+    where,
+  } = filter;
+  let candidateProperty, candidateRelations;
+  const innerJoins = [];
+  const innerOrder = {};
+  const innerWhere = {};
+  if (!where && !order) {
+    return new ParameterizedSQL('');
+  }
+  if ((typeof where !== 'object' || Array.isArray(where)) && !order) {
+    debug('Invalid value for where: %j', where);
+    return new ParameterizedSQL('');
+  }
+  const self = this;
+  const props = self.getModelDefinition(model).properties;
+  let basePrefix = 0;
+
+  const _buildJoin = (key, type) => {
+    let orderValue = '';
+    if (type === 'order') {
+      const t = key.split(/[\s,]+/);
+      orderValue = t.length === 1 ? '' : t[1];
+      key = t.length === 1 ? key : t[0];
+    }
+    let p = props[key];
+    if (p) {
+      return;
+    }
+    if (p == null && isNested(key)) {
+      p = props[key.split('.')[0]];
+    }
+    if (p) {
+      return;
+    }
+    // It may be an innerWhere
+    const splitedKey = key.split('.');
+    if (splitedKey.length === 1) {
+      debug('Unknown property %s is skipped for model %s', key, model);
+      return;
+    }
+    // Pop the property
+    candidateProperty = splitedKey.pop();
+    // Keep the candidate relations
+    candidateRelations = splitedKey;
+    let parentModel = model;
+    let parentPrefix = '';
+    for (let i = 0; i < candidateRelations.length; i++) {
+      // Build a prefix for alias to prevent conflict
+      const prefix = `_${basePrefix}_${i}_`;
+      const candidateRelation = candidateRelations[i];
+      const modelDefinition = this.getModelDefinition(parentModel);
+
+      if (!modelDefinition) {
+        debug('No definition for model %s', parentModel);
+        break;
+      }
+      // The next line need a monkey patch of @loopback/repository to add relations to modelDefinition */
+      if (!(candidateRelation in modelDefinition.settings.__relations__)) {
+        debug('No relation for model %s', parentModel);
+        break;
+      }
+      const relation =
+        modelDefinition.settings.__relations__[candidateRelation];
+      // Only supports belongsTo and hasOne
+      if (relation.type !== 'belongsTo' && relation.type !== 'hasOne') {
+        debug('Invalid relation type for model %s for inner join', parentModel);
+        break;
+      }
+
+      const target = relation.target();
+      const targetDefinition = this.getModelDefinition(target.modelName);
+      let hasProp = true;
+      if (!(candidateProperty in targetDefinition.properties)) {
+        if (targetDefinition.settings.__relations__[candidateRelations[i + 1]]) {
+          hasProp = false;
+        } else {
+          debug(
+            'Unknown property %s is skipped for model %s',
+            candidateProperty,
+            target.modelName,
+          );
+          break;
+        }
+      }
+
+      // Check if join already done
+      let alreadyJoined = false;
+      for (const innerJoin of innerJoins) {
+        if (
+          innerJoin.model === target.modelName &&
+          innerJoin.parentModel === parentModel
+        ) {
+          alreadyJoined = true;
+          // Keep what needed to build the WHERE or ORDER statement properly
+          if (type === 'where' && hasProp) {
+            innerWhere[key] = {
+              prefix: innerJoin.prefix,
+              model: innerJoin.model,
+              property: {
+                ...targetDefinition.properties[candidateProperty],
+                key: candidateProperty,
+              },
+              value: where[key],
+            };
+          } else if (type === 'order' && hasProp) {
+            innerOrder[key] = {
+              prefix: innerJoin.prefix,
+              model: innerJoin.model,
+              property: {
+                ...targetDefinition.properties[candidateProperty],
+                key: candidateProperty,
+              },
+              value: orderValue,
+            };
+          }
+        }
+      }
+      // Keep what needed to build INNER JOIN AS statement
+      if (!alreadyJoined) {
+        innerJoins.push({
+          prefix,
+          parentPrefix,
+          parentModel,
+          relation: {
+            ...relation,
+            name: candidateRelation,
+          },
+          model: target.modelName,
+        });
+        // Keep what needed to build the WHERE or ORDER statement properly
+        if (type === 'where' && hasProp) {
+          innerWhere[key] = {
+            prefix,
+            model: target.modelName,
+            property: {
+              ...targetDefinition.properties[candidateProperty],
+              key: candidateProperty,
+            },
+            value: where[key],
+          };
+        } else if (type === 'order' && hasProp) {
+          innerOrder[key] = {
+            prefix,
+            model: target.modelName,
+            property: {
+              ...targetDefinition.properties[candidateProperty],
+              key: candidateProperty,
+            },
+            value: orderValue,
+          };
+        }
+      }
+      // Keep the parentModel for recursive INNER JOIN and parentPrefix for the alias
+      parentModel = target.modelName;
+      parentPrefix = prefix;
+    }
+    basePrefix++;
+  };
+
+  for (const key in where) {
+    _buildJoin(key, 'where');
+  }
+  let orderArray = order;
+  if (typeof order === 'string') {
+    orderArray = [order];
+  }
+  for (const key of orderArray) {
+    _buildJoin(key, 'order');
+  }
+
+  const joinStmt = {
+    sql: '',
+  };
+
+  for (const innerJoin of innerJoins) {
+    joinStmt.sql += `INNER JOIN ${self.tableEscaped(
+      innerJoin.model,
+    )} AS ${self.escapeName(innerJoin.prefix + innerJoin.relation.name)} `;
+    /** @todo Fix ::uuid to be dynamic */
+    joinStmt.sql += `ON ${self.columnEscaped(
+      innerJoin.parentModel,
+      innerJoin.relation.keyFrom,
+      true,
+      innerJoin.parentPrefix,
+    )}${
+      innerJoin.relation.type === 'belongsTo' ? '::uuid' : ''
+    } = ${self.columnEscaped(
+      innerJoin.model,
+      innerJoin.relation.keyTo,
+      true,
+      innerJoin.prefix,
+    )}${innerJoin.relation.type === 'hasOne' ? '::uuid' : ''} `;
+  }
+
+  return {
+    joinStmt,
+    innerWhere,
+    innerOrder,
+  };
+};
+
+/**
+ * Build the SQL WHERE clause for the filter object
+ * @param {string} model Model name
+ * @param {object} filter An object for the filter conditions
  * @returns {ParameterizedSQL} The SQL WHERE clause
  */
-PostgreSQL.prototype.buildWhere = function(model, where) {
-  const whereClause = this._buildWhere(model, where);
+PostgreSQL.prototype.buildWhere = function(model, filter) {
+  const whereClause = this._buildWhere(model, filter);
   if (whereClause.sql) {
     whereClause.sql = 'WHERE ' + whereClause.sql;
   }
@@ -576,12 +938,23 @@ PostgreSQL.prototype.buildWhere = function(model, where) {
 /**
  * @private
  * @param model
- * @param where
+ * @param filter
  * @returns {ParameterizedSQL}
  */
-PostgreSQL.prototype._buildWhere = function(model, where) {
+PostgreSQL.prototype._buildWhere = function(model, filter) {
+  const {
+    innerWhere,
+  } = filter;
+  let {
+    where,
+  } = filter;
   let columnValue, sqlExp;
-  if (!where) {
+  let withTable = true;
+  if (!where && !innerWhere) {
+    withTable = false;
+    where = filter;
+  }
+  if (!filter) {
     return new ParameterizedSQL('');
   }
   if (typeof where !== 'object' || Array.isArray(where)) {
@@ -593,6 +966,7 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
 
   const whereStmts = [];
   for (const key in where) {
+    let innerJoin = false;
     const stmt = new ParameterizedSQL('', []);
     // Handle and/or operators
     if (key === 'and' || key === 'or') {
@@ -623,6 +997,15 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
       // See if we are querying nested json
       p = props[key.split('.')[0]];
     }
+    // It may be an innerWhere
+    if (p == null) {
+      if (innerWhere[key]) {
+        p = innerWhere[key].property;
+      }
+      if (p) {
+        innerJoin = true;
+      }
+    }
 
     if (p == null) {
       // Unknown property, ignore it
@@ -630,8 +1013,17 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
       continue;
     }
     // eslint-disable one-var
-    let expression = where[key];
-    const columnName = self.columnEscaped(model, key);
+    let expression = innerJoin ? innerWhere[key].value : where[key];
+    // Use alias from INNER JOIN AS builder
+    const columnName = innerJoin ?
+      self.columnEscaped(
+        innerWhere[key].model,
+        innerWhere[key].property.key,
+        true,
+        innerWhere[key].prefix,
+      ) :
+      self.columnEscaped(model, key, withTable);
+
     // eslint-enable one-var
     if (expression === null || expression === undefined) {
       stmt.merge(columnName + ' IS NULL');
@@ -682,8 +1074,7 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
         if (columnValue instanceof ParameterizedSQL) {
           if (p.type.name === 'GeoPoint')
             stmt.merge(columnName + '~=').merge(columnValue);
-          else
-            stmt.merge(columnName + '=').merge(columnValue);
+          else stmt.merge(columnName + '=').merge(columnValue);
         } else {
           stmt.merge({
             sql: columnName + '=?',
@@ -697,8 +1088,10 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
   let params = [];
   const sqls = [];
   for (let k = 0, s = whereStmts.length; k < s; k++) {
-    sqls.push(whereStmts[k].sql);
-    params = params.concat(whereStmts[k].params);
+    if (whereStmts[k].sql) {
+      sqls.push(whereStmts[k].sql);
+      params = params.concat(whereStmts[k].params);
+    }
   }
   const whereStmt = new ParameterizedSQL({
     sql: sqls.join(' AND '),
@@ -768,7 +1161,8 @@ PostgreSQL.prototype.toColumnValue = function(prop, val, isWhereClause) {
 
   if (Array.isArray(prop.type)) {
     // There is two possible cases for the type of "val" as well as two cases for dataType
-    const isArrayDataType = prop.postgresql && prop.postgresql.dataType === 'varchar[]';
+    const isArrayDataType =
+      prop.postgresql && prop.postgresql.dataType === 'varchar[]';
     if (Array.isArray(val)) {
       if (isArrayDataType) {
         return val;

--- a/test/postgresql.order.test.js
+++ b/test/postgresql.order.test.js
@@ -94,7 +94,8 @@ describe('Order settings', function() {
     const res = db.connector.buildSelect('PostWithDefaultIdSort', {});
     const sql = res.sql;
 
-    sql.should.be.equal('SELECT "id","title","content" FROM "public"."postwithdefaultidsort" ORDER BY "id"');
+    sql.should.be.equal('SELECT "postwithdefaultidsort"."id","postwithdefaultidsort"."title",' +
+     '"postwithdefaultidsort"."content" FROM "public"."postwithdefaultidsort"  ORDER BY "postwithdefaultidsort"."id"');
     done();
   });
 
@@ -102,7 +103,8 @@ describe('Order settings', function() {
     const res = db.connector.buildSelect('PostWithDisabledDefaultIdSort', {});
     const sql = res.sql;
 
-    sql.should.be.equal('SELECT "id","title","content" FROM "public"."postwithdisableddefaultidsort"');
+    sql.should.be.equal('SELECT "postwithdisableddefaultidsort"."id","postwithdisableddefaultidsort"."title",' +
+      '"postwithdisableddefaultidsort"."content" FROM "public"."postwithdisableddefaultidsort"');
     done();
   });
 
@@ -110,7 +112,9 @@ describe('Order settings', function() {
     const res = db.connector.buildSelect('PostWithNumericDefaultIdSort', {});
     const sql = res.sql;
 
-    sql.should.be.equal('SELECT "id","title","content" FROM "public"."postwithnumericdefaultidsort" ORDER BY "id"');
+    sql.should.be.equal('SELECT "postwithnumericdefaultidsort"."id","postwithnumericdefaultidsort"."title",' +
+      '"postwithnumericdefaultidsort"."content" FROM "public"."postwithnumericdefaultidsort"' +
+      '  ORDER BY "postwithnumericdefaultidsort"."id"');
     done();
   });
 
@@ -118,7 +122,9 @@ describe('Order settings', function() {
     const res = db.connector.buildSelect('PostWithNumericStringDefaultIdSort', {});
     const sql = res.sql;
 
-    sql.should.be.equal('SELECT "id","title","content" FROM "public"."postwithnumericstringdefaultidsort"');
+    sql.should.be.equal('SELECT "postwithnumericstringdefaultidsort"."id",' +
+      '"postwithnumericstringdefaultidsort"."title","postwithnumericstringdefaultidsort"."content"' +
+      ' FROM "public"."postwithnumericstringdefaultidsort"');
     done();
   });
 


### PR DESCRIPTION
Support for recursive `INNER JOIN`
Support for *inner* `ORDER BY` and `WHERE`

Only `hasOne` and `belongsTo` relations supported.

Example of query using inner joins : 
```
{
  "where": {
    "user.contact.email": "mail@domain.tld",
    "profile.name": "support"
  },
  "include": [
    {
      "relation": "user",
      "scope": {
        "include" : [
           {
             "relation": "contact"
           }
        ]
      }
    },
    {
      "relation": "profile"
    }
  ],
  "order": "user.contact.email ASC"
}
``` 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
