### PR TITLE
fix: escape table name for alias instead of relation name

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -321,8 +321,8 @@ PostgreSQL.prototype.buildSelect = function(model, filter, options = {}, count =
   }
 
   const selectSql = count ?
-    'count(' + this.tableEscaped(model) + '.' + this.idNames(model) + ') as "cnt"'
-    : this.buildColumnNames(model, filter, true);
+    'count(' + this.tableEscaped(model) + '.' + this.idNames(model) + ') as "cnt"' :
+    this.buildColumnNames(model, filter, true);
 
   let selectStmt = new ParameterizedSQL(
     'SELECT ' +
@@ -948,7 +948,7 @@ PostgreSQL.prototype.buildJoin = function(model, filter) {
   for (const innerJoin of innerJoins) {
     joinStmt.sql += `INNER JOIN ${self.tableEscaped(
       innerJoin.model,
-    )} AS ${self.escapeName(innerJoin.prefix + innerJoin.relation.name)} `;
+    )} AS ${self.escapeName(innerJoin.prefix + self.table(innerJoin.model))} `;
     /** @todo Fix ::uuid to be dynamic */
     joinStmt.sql += `ON ${self.columnEscaped(
       innerJoin.parentModel,


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-postgresql) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
